### PR TITLE
セットアップスクリプトのバグ修正

### DIFF
--- a/src/000_setup/05_Create-SharePointSite/Create-SharepointSite.ps1
+++ b/src/000_setup/05_Create-SharePointSite/Create-SharepointSite.ps1
@@ -1,16 +1,16 @@
 <#
     .SYNOPSIS
-        SharePoint„Çµ„Ç§„Éà„ÅÆ‰ΩúÊàê
+        SharePointÉTÉCÉgÇÃçÏê¨
 
     .DESCRIPTION
-        M365„ÉÜ„Éä„É≥„Éà„Éá„Éº„Çø„ÇíËìÑÁ©ç„Åô„Çã„Åü„ÇÅ„ÅÆSharePoint„Çµ„Ç§„Éà„ÅÆ‰ΩúÊàê
-        Âèä„Å≥„ÄÅEntra ID „Ç¢„Éó„É™„Ç±„Éº„Ç∑„Éß„É≥„Å∏„ÅÆÊ®©Èôê‰ªò‰∏é
+        M365ÉeÉiÉìÉgÉfÅ[É^Çí~êœÇ∑ÇÈÇΩÇﬂÇÃSharePointÉTÉCÉgÇÃçÏê¨
+        ãyÇ—ÅAEntra ID ÉAÉvÉäÉPÅ[ÉVÉáÉìÇ÷ÇÃå†å¿ïtó^
 
     .PARAMETER applicationId
-        [ÂøÖÈ†à] Entra ID „Ç¢„Éó„É™„Ç±„Éº„Ç∑„Éß„É≥ID
+        [ïKê{] Entra ID ÉAÉvÉäÉPÅ[ÉVÉáÉìID
 
     .PARAMETER securityGroupObjectId
-        [ÂøÖÈ†à] SharePoint„Çµ„Ç§„Éà„Å´ÂØæ„Åó„Å¶„Ç¢„ÇØ„Çª„ÇπÊ®©„Çí‰ªò‰∏é„Åô„Çã„Åü„ÇÅ„ÅÆEntra ID „Çª„Ç≠„É•„É™„ÉÜ„Ç£„Ç∞„É´„Éº„Éó„ÅÆObject ID
+        [ïKê{] SharePointÉTÉCÉgÇ…ëŒÇµÇƒÉAÉNÉZÉXå†Çïtó^Ç∑ÇÈÇΩÇﬂÇÃEntra ID ÉZÉLÉÖÉäÉeÉBÉOÉãÅ[ÉvÇÃObject ID
 
     .EXAMPLE
         PS> Create-SharepointSite.ps1 -applicationId "your-application-id" -securityGroupObjectId "your-security-group-object-id"
@@ -130,7 +130,7 @@ try {
     $group = Get-SPOSiteGroup -Site $siteUrl | Where-Object { $_.Title -eq $groupName }
 
     if ($null -eq $group) {
-    New-SPOSiteGroup -Site $siteUrl -Group $groupName -PermissionLevels "Full Control"
+    New-SPOSiteGroup -Site $siteUrl -Group $groupName -PermissionLevels "ÉtÉã ÉRÉìÉgÉçÅ[Éã"
     }
 
     Add-SPOUser -Site $siteUrl -LoginName $securityGroupLoginName -Group $groupName


### PR DESCRIPTION
## 概要
- セキュリティグループに対してSharePointサイトへのフルコントロール権限付与時のバグ修正

## 変更点
- "Full Controll"→"フル コントロール"に権限の指定方法を変更
- 日本語の言語設定である前提に変更
- ファイルの文字コードをUTF-8からShift-JISに変更

## 背景
- 権限付与時に"Full Controll"で指定するとエラーが発生することがあったため。

## 関連するIssue
- Issue番号: #

## 確認項目
- [ ] 既存の機能への影響範囲を確認しました。
- [ ] 修正した内容が期待通り動作することを確認しました。
- [ ] 既存の他の機能への影響がないことを確認しました。
- [ ] 関連するドキュメントが最新の状態に更新しました。

## その他
